### PR TITLE
Filter out duplicate post owners from API response

### DIFF
--- a/facebook_posts/models.py
+++ b/facebook_posts/models.py
@@ -175,7 +175,10 @@ class Post(AuthorableModelMixin, LikableModelMixin, CommentableModelMixin, Share
         if 'from' in response:
             response['author_json'] = response.pop('from')
         if 'to' in response and len(response['to']['data']):
-            response['owners_json'] = response.pop('to')['data']
+            response['owners_json'] = []
+            for owner in response.pop('to')['data']:
+                if owner not in response['owners_json']:
+                    response['owners_json'].append(owner)
 
         for field in ['likes', 'comments', 'shares']:
             if field in response:


### PR DESCRIPTION
Facebook seems to sometimes return the same post owner twice. Without filtering the duplicates out, saving to the database results in duplicate key errors.

Fixes #3